### PR TITLE
Change backticks to apostrophes

### DIFF
--- a/setup/win-2019-worker.ps1
+++ b/setup/win-2019-worker.ps1
@@ -13,7 +13,7 @@ docker image tag mcr.microsoft.com/windows/nanoserver:1809 microsoft/nanoserver:
 # download the Kube binaries
 mkdir -p C:\k\logs
 cd C:\k
-$ProgressPreference=’SilentlyContinue’
+$ProgressPreference='SilentlyContinue'
 iwr -outf kubernetes-node-windows-amd64.tar.gz "https://dl.k8s.io/v$KUBERNETES_VERSION/kubernetes-node-windows-amd64.tar.gz"
 
 tar -xkf kubernetes-node-windows-amd64.tar.gz -C C:\k

--- a/setup/win-2019-worker.ps1
+++ b/setup/win-2019-worker.ps1
@@ -89,3 +89,5 @@ $sourceVipJSON = Get-Content sourceVip.json | ConvertFrom-Json
 $sourceVip = $sourceVipJSON.ip4.ip.Split("/")[0]
 .\nssm.exe set $KubeProxySvc AppParameters --v=4 --proxy-mode=kernelspace --feature-gates="WinOverlay=true" --hostname-override=$Hostname --kubeconfig=c:\k\config --network-name=vxlan0 --source-vip=$sourceVip --enable-dsr=false --cluster-cidr=$ClusterCIDR --log-dir=$LogDir --logtostderr=false
 .\nssm.exe set $KubeProxySvc DependOnService $KubeletSvc
+.\nssm.exe start $KubeProxySvc
+

--- a/setup/win-2019-worker.ps1
+++ b/setup/win-2019-worker.ps1
@@ -89,4 +89,3 @@ $sourceVipJSON = Get-Content sourceVip.json | ConvertFrom-Json
 $sourceVip = $sourceVipJSON.ip4.ip.Split("/")[0]
 .\nssm.exe set $KubeProxySvc AppParameters --v=4 --proxy-mode=kernelspace --feature-gates="WinOverlay=true" --hostname-override=$Hostname --kubeconfig=c:\k\config --network-name=vxlan0 --source-vip=$sourceVip --enable-dsr=false --cluster-cidr=$ClusterCIDR --log-dir=$LogDir --logtostderr=false
 .\nssm.exe set $KubeProxySvc DependOnService $KubeletSvc
-.\nssm.exe start $KubeProxySvc

--- a/setup/win-2019-worker.ps1
+++ b/setup/win-2019-worker.ps1
@@ -89,4 +89,4 @@ $sourceVipJSON = Get-Content sourceVip.json | ConvertFrom-Json
 $sourceVip = $sourceVipJSON.ip4.ip.Split("/")[0]
 .\nssm.exe set $KubeProxySvc AppParameters --v=4 --proxy-mode=kernelspace --feature-gates="WinOverlay=true" --hostname-override=$Hostname --kubeconfig=c:\k\config --network-name=vxlan0 --source-vip=$sourceVip --enable-dsr=false --cluster-cidr=$ClusterCIDR --log-dir=$LogDir --logtostderr=false
 .\nssm.exe set $KubeProxySvc DependOnService $KubeletSvc
-.\nssm.exe start $KubeProxySvc
+.\nssm.exe start $KubeProxySvc 

--- a/setup/win-2019-worker.ps1
+++ b/setup/win-2019-worker.ps1
@@ -90,4 +90,3 @@ $sourceVip = $sourceVipJSON.ip4.ip.Split("/")[0]
 .\nssm.exe set $KubeProxySvc AppParameters --v=4 --proxy-mode=kernelspace --feature-gates="WinOverlay=true" --hostname-override=$Hostname --kubeconfig=c:\k\config --network-name=vxlan0 --source-vip=$sourceVip --enable-dsr=false --cluster-cidr=$ClusterCIDR --log-dir=$LogDir --logtostderr=false
 .\nssm.exe set $KubeProxySvc DependOnService $KubeletSvc
 .\nssm.exe start $KubeProxySvc
-


### PR DESCRIPTION
Hi Elton,
I am following your excellent blog post 
https://blog.sixeyed.com/getting-started-with-kubernetes-on-windows/, 
but the script from https://raw.githubusercontent.com/sixeyed/k8s-win/master/setup/win-2019-worker.ps1 seems to have SilentlyContinue enclosed in backticks, which is failing on it.
I was getting error
```
â€™SilentlyContinueâ€™ : The term 'â€™SilentlyContinueâ€™' is not recognized as the name of a cmdlet, function, script
file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct
and try again.
```
until I changed them to apostrophes. I hope I haven't broke any deeper idea.
Thank you